### PR TITLE
Add AWS IAM Credential Support to apt-golang-s3

### DIFF
--- a/method/method.go
+++ b/method/method.go
@@ -315,8 +315,7 @@ func (m *Method) s3Client(s3Uri *url.URL) s3iface.S3API {
 		if !hasPass {
 			m.handleError(errors.New("acquire message missing required value: Password"))
 		}
-		creds = credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, "")
-		config.Credentials = creds
+		config.Credentials = credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, "")
 	}
 	sess := session.Must(session.NewSession())
 	return s3.New(sess, config)

--- a/method/method.go
+++ b/method/method.go
@@ -310,7 +310,6 @@ func (m *Method) s3Client(s3Uri *url.URL) s3iface.S3API {
 	var config = &aws.Config{
 		Region: aws.String(m.region),
 	}
-	var creds *credentials.Credentials
 	if awsAccessKeyID != "" {
 		if !hasPass {
 			m.handleError(errors.New("acquire message missing required value: Password"))

--- a/method/method.go
+++ b/method/method.go
@@ -307,7 +307,7 @@ func (m *Method) uriAcquire(msg *message.Message) {
 func (m *Method) s3Client(s3Uri *url.URL) s3iface.S3API {
 	awsAccessKeyID := s3Uri.User.Username()
 	awsSecretAccessKey, hasPass := s3Uri.User.Password()
-	var config = &aws.Config{
+	config := &aws.Config{
 		Region: aws.String(m.region),
 	}
 	if awsAccessKeyID != "" {


### PR DESCRIPTION
One of the things I'd like to get away from is having to use credentials at all in my s3 resources and instead rely on the host's IAM role. This patch will make that happen - using static credentials if they're there, and falling back on the default AWS Credential Provider Path if they are not.

This is, admittedly, difficult to test. The existing test should pass fine, but short of spinning up an EC2 node with host credentials I'm not sure how to write a test for it. Suggestions welcome there.

In any case, thanks for creating this tool. It solves my problem of having to install an entire python toolchain just to get some updates from s3, which makes me pretty thrilled :+1: