### PR TITLE
Fix issue with URL parsing error not being handled

### DIFF
--- a/method/method.go
+++ b/method/method.go
@@ -231,7 +231,7 @@ type objectLocation struct {
 func newLocation(value string) (objectLocation, error) {
 	uri, err := url.Parse(value)
 	if err != nil {
-		return objectLocation{}, nil
+		return objectLocation{}, err
 	}
 	if uri.Host == s3Hostname {
 		tokens := strings.Split(uri.Path, "/")


### PR DESCRIPTION
The following fix an issue where invalid URLs that failed to parse was causing the transport to crash with a nil pointer crash.

I discovered the issue when using URLs like the following `deb s3://access_key:secret/key@s3.amazonaws.com/some-bucket` which fails to parse due to the slash in the secret key. Granted the secret key should have been URL encoded but the issue was hard to discover due to the nil pointer crash.
