### PR TITLE
update travis golang versions to 1.13 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
   - linux
 
 go:
-  - "1.11.x"
+  - "1.13.x"
+  - "1.14.x"
+  - "1.15.x"
 
 script: go test -v ./...


### PR DESCRIPTION
1.13 was released in 9/2019 https://golang.org/doc/devel/release.html