### PR TITLE
preprocess urls to avoid errors in parsing

### DIFF
--- a/method/method_test.go
+++ b/method/method_test.go
@@ -115,14 +115,24 @@ var locTests = []locTest{
 		"fake-access-key-secret",
 	},
 	{
-		"s3://fake-access-key-id:fake-ac/cess-key-secret@s3.amazonaws.com/apt-repo-bucket/apt/generic/python-bernhard_0.2.3-1_all.deb",
-		"fake-access-key-id",
-		"fake-ac/cess-key-secret", // note the invalid extra forward slash
+		"s3://fake-ac/cess-key-id:fake-ac/cess-key-secret@s3.amazonaws.com/apt-repo-bucket/apt/generic/python-bernhard_0.2.3-1_all.deb",
+		"fake-ac/cess-key-id",
+		"fake-ac/cess-key-secret", // secret contains a forward slash
 	},
 	{
-		"s3://fake-access-key-id:fake-ac%2Fcess-key-secret@s3.amazonaws.com/apt-repo-bucket/apt/generic/python-bernhard_0.2.3-1_all.deb",
+		"s3://fake-ac%2Fcess-key-id:fake-ac%2Fcess-key-secret@s3.amazonaws.com/apt-repo-bucket/apt/generic/python-bernhard_0.2.3-1_all.deb",
+		"fake-ac/cess-key-id",     // access key contains a forward slash that was encoded as %2F in the original url
+		"fake-ac/cess-key-secret", // secret contains a forward slash that was encoded as %2F in the original url
+	},
+	{
+		"s3://fake-access-key-id:@s3.amazonaws.com/apt-repo-bucket/apt/generic/python-bernhard_0.2.3-1_all.deb",
 		"fake-access-key-id",
-		"fake-ac/cess-key-secret", // note the invalid extra forward slash
+		"", // secret is blank
+	},
+	{
+		"s3://:fake-access-key-secret@s3.amazonaws.com/apt-repo-bucket/apt/generic/python-bernhard_0.2.3-1_all.deb",
+		"", // access key is blank
+		"fake-access-key-secret",
 	},
 }
 

--- a/method/method_test.go
+++ b/method/method_test.go
@@ -101,3 +101,43 @@ func TestSettingRegion(t *testing.T) {
 		t.Errorf("method.region = %s; expected %s", method.region, expected)
 	}
 }
+
+type locTest struct {
+	url             string
+	accessKey       string
+	accessKeySecret string
+}
+
+var locTests = []locTest{
+	{
+		"s3://fake-access-key-id:fake-access-key-secret@s3.amazonaws.com/apt-repo-bucket/apt/generic/python-bernhard_0.2.3-1_all.deb",
+		"fake-access-key-id",
+		"fake-access-key-secret",
+	},
+	{
+		"s3://fake-access-key-id:fake-ac/cess-key-secret@s3.amazonaws.com/apt-repo-bucket/apt/generic/python-bernhard_0.2.3-1_all.deb",
+		"fake-access-key-id",
+		"fake-ac/cess-key-secret", // note the invalid extra forward slash
+	},
+	{
+		"s3://fake-access-key-id:fake-ac%2Fcess-key-secret@s3.amazonaws.com/apt-repo-bucket/apt/generic/python-bernhard_0.2.3-1_all.deb",
+		"fake-access-key-id",
+		"fake-ac/cess-key-secret", // note the invalid extra forward slash
+	},
+}
+
+func TestCreateLocation(t *testing.T) {
+	for _, lt := range locTests {
+		l, err := newLocation(lt.url, "s3.amazonaws.com")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if l.uri.User.Username() != lt.accessKey {
+			t.Errorf("unexpected accessKey: got %s, want %s", l.uri.User.Username(), lt.accessKey)
+		}
+		pass, _ := l.uri.User.Password()
+		if pass != lt.accessKeySecret {
+			t.Errorf("unexpected accessKeySecret: got %s, want %s", pass, lt.accessKeySecret)
+		}
+	}
+}


### PR DESCRIPTION
According to [RFC 1738](https://tools.ietf.org/html/rfc1738) slashes are not permitted in user or password parts of a url. Unfortunately, amazon occasionally generates secret access keys with forward slashes, so they need to be escaped.

See [Section 5](https://tools.ietf.org/html/rfc1738#section-5) for more details on permissible characters.

Fixes https://github.com/google/apt-golang-s3/issues/11